### PR TITLE
Recommendations: Quick fix to load images from URLs

### DIFF
--- a/orangecontrib/pumice/widgets/tests/test_owrecommendation.py
+++ b/orangecontrib/pumice/widgets/tests/test_owrecommendation.py
@@ -490,8 +490,9 @@ class TestOWRecommendation(WidgetTest):
         w.rec_model.set_data.assert_called()
 
     @patch("os.path.exists", new=lambda x: bool(ord(x[-1]) % 2))
+    @patch("builtins.open")
     @patch("orangecontrib.pumice.widgets.owrecommendation.QPixmap")
-    def test_set_images(self, _):
+    def test_set_images(self, *_):
         w = self.widget
 
         w.image_column = None


### PR DESCRIPTION
##### Issue

data.pumice.si now gives a single .xlsx file with image URLs, but the widget can only load local files.

##### Description of changes

This is a quick fix that synchronously loads all files. A proper fix would do this asynchronously, but this will require taking the code (or importing) from Image Viewer, and possibly reimplementing this widget's model. Therefore only a quick fix for now.

##### Includes
- [X] Code changes
