### PR TITLE
Compair: Fix incorrect import of logistic regression

### DIFF
--- a/orangecontrib/pumice/widgets/owcompair.py
+++ b/orangecontrib/pumice/widgets/owcompair.py
@@ -20,7 +20,7 @@ from orangewidget.widget import Msg
 from Orange.data import Table, StringVariable, Domain, DiscreteVariable
 from Orange.widgets import gui
 from Orange.widgets.widget import OWWidget, Input
-from Orange.classification import (
+from Orange.classification.logistic_regression import (
     LogisticRegressionLearner, LogisticRegressionClassifier)
 
 


### PR DESCRIPTION
##### Issue

`LogisticRegressionClassifier` is not exported from `Orange.classification`.

##### Description of changes

Import from `Orange.classification.logistic_regression`.
