### PR TITLE
Compair: Fix for Qt6 (no qApp)

### DIFF
--- a/orangecontrib/pumice/widgets/owcompair.py
+++ b/orangecontrib/pumice/widgets/owcompair.py
@@ -10,7 +10,7 @@ import numpy as np
 from AnyQt.QtCore import Qt
 from AnyQt.QtGui import QPixmap, QFont, QPainter, QColor
 from AnyQt.QtWidgets import (
-    qApp, QHBoxLayout, QWidget, QGridLayout, QSizePolicy, QLabel, QPushButton)
+    QApplication, QHBoxLayout, QWidget, QGridLayout, QSizePolicy, QLabel, QPushButton)
 
 from orangewidget.settings import Setting
 from orangewidget.utils.signals import Output
@@ -385,13 +385,13 @@ class OWComPair(OWWidget):
         with self.disabled_buttons():
             for _ in range(10):
                 self.advance_state()
-                qApp.processEvents()
+                QApplication.instance().processEvents()
 
     def finish(self):
         with self.disabled_buttons():
             while self.state != self.NoMore:
                 self.advance_state()
-                qApp.processEvents()
+                QApplication.instance().processEvents()
 
     def advance_state(self):
         if self.state == self.ShowingPair:


### PR DESCRIPTION
##### Issue

Widget ComPair doesn't register (and import) on Qt6-based Orange that doesn't have `qApp`.

##### Description of changes

Replace `qApp` with `QApplication.instance()`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
